### PR TITLE
Add Tool-Call Tactics CTA and project card

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,56 @@
+# Plan: Add Tool-Call Tactics CTA to Portfolio Hero Section
+
+## Goal
+Add a callout in the hero section that invites visitors to try Tool-Call Tactics — a game that demonstrates how an AI agent reasons.
+
+## What to Change
+
+### File: `src/components/Hero.js`
+
+Add a new `motion.div` block **below the social links** (after line 118, before the closing `</div>` of the glass card on line 119) with:
+
+- A short teaser line: **"Wanna see how an AI agent reasons?"**
+- A CTA link button: **"Try Tool-Call Tactics →"** linking to `https://toolcalltactics.loukik.dev`
+- Styled to match the existing glass-morphism aesthetic
+- Uses Framer Motion for entrance animation (part of the existing `itemVariants` stagger)
+- Opens in a new tab
+
+### Proposed JSX
+
+```jsx
+<motion.div
+  className="mt-8 flex flex-col items-center lg:items-start gap-3"
+  variants={itemVariants}
+>
+  <p className="text-on-glass-muted text-sm">
+    Wanna see how an AI agent reasons?
+  </p>
+  <motion.a
+    href="https://toolcalltactics.loukik.dev"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-2 px-6 py-3 glass rounded-2xl text-sky-400 font-medium hover:text-white transition-all duration-300 border border-sky-400/30 hover:border-sky-400/60"
+    whileHover={{ scale: 1.05, y: -2 }}
+    whileTap={{ scale: 0.95 }}
+  >
+    🎮 Try Tool-Call Tactics →
+  </motion.a>
+</motion.div>
+```
+
+### Placement
+```
+[Glass Card]
+  ├── "Hi, I'm Loukik"
+  ├── TypeWriter roles
+  ├── Description paragraph
+  ├── Social links (GitHub, LinkedIn, Email)
+  └── NEW: Tool-Call Tactics CTA  ← here
+[/Glass Card]
+```
+
+## No Other Changes Needed
+- No new dependencies
+- No new components
+- No CSS/Tailwind config changes (uses existing utility classes)
+- Single file change: `src/components/Hero.js`

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -52,7 +52,7 @@ const Hero = () => {
       className="pt-32 pb-20 min-h-screen flex items-center relative overflow-hidden"
     >
       <div className="container mx-auto px-6 relative z-10">
-        <div className="flex flex-col lg:flex-row items-center gap-12">
+        <div className="flex flex-col-reverse lg:flex-row items-center gap-12">
           <motion.div
             className="lg:w-1/2 text-center lg:text-left"
             variants={containerVariants}
@@ -116,6 +116,43 @@ const Hero = () => {
                   <FaEnvelope size={28} />
                 </motion.a>
               </motion.div>
+              <motion.a
+                href="https://toolcalltactics.loukik.dev"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-10 block group"
+                variants={itemVariants}
+              >
+                <motion.div
+                  className="glass rounded-2xl border border-sky-400/20 hover:border-sky-400/50 transition-all duration-300 overflow-hidden"
+                  whileHover={{ scale: 1.02, y: -4 }}
+                  whileTap={{ scale: 0.98 }}
+                >
+                  <div className="relative w-full h-44 bg-gradient-to-br from-slate-900 to-slate-800 overflow-hidden">
+                    <iframe
+                      src="https://toolcalltactics.loukik.dev"
+                      title="Tool-Call Tactics Preview"
+                      className="w-[200%] h-[200%] origin-top-left scale-50 pointer-events-none"
+                      loading="lazy"
+                      tabIndex={-1}
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
+                  </div>
+                  <div className="p-5 flex items-center justify-between">
+                    <div>
+                      <h3 className="text-lg font-semibold text-on-glass group-hover:text-sky-400 transition-colors">
+                        🎮 Tool-Call Tactics
+                      </h3>
+                      <p className="text-on-glass-muted text-sm mt-1">
+                        See how an AI agent reasons, play the game!
+                      </p>
+                    </div>
+                    <span className="text-sky-400 text-xl group-hover:translate-x-1 transition-transform duration-300">
+                      →
+                    </span>
+                  </div>
+                </motion.div>
+              </motion.a>
             </div>
           </motion.div>
 

--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -11,6 +11,16 @@ import emailClassifierImage from '../assets/email.jpg';
 const Projects = () => {
   const projects = [
     {
+      title: 'Tool-Call Tactics',
+      description:
+        'An interactive game that lets you experience how an AI agent reasons through tool calls. Watch and play as the agent decides which tools to use and why.',
+      iframePreview: 'https://toolcalltactics.loukik.dev',
+      technologies: ['AI Agents', 'Tool Use', 'Interactive', 'Game'],
+      github: 'https://github.com/LoukikNaik/tool-call-tactics',
+      live: 'https://toolcalltactics.loukik.dev',
+    },
+
+    {
       title: 'Surfstore: Distributed File Storage System',
       description:
         'Implemented a horizontally scalable file storage system using Go and gRPC. Features multiple block/metadata servers and Raft consensus for reliable data synchronization across servers.',
@@ -153,7 +163,7 @@ const Projects = () => {
           Projects
         </motion.h2>
         <motion.div
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-7xl mx-auto"
+          className="flex flex-wrap justify-center gap-8 max-w-7xl mx-auto"
           variants={containerVariants}
           initial="hidden"
           whileInView="visible"
@@ -162,12 +172,20 @@ const Projects = () => {
           {projects.map((project, index) => (
             <motion.div
               key={index}
-              className="glass-strong rounded-3xl overflow-hidden hover:scale-105 transition-all duration-300 group"
+              className="glass-strong rounded-3xl overflow-hidden hover:scale-105 transition-all duration-300 group w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.4rem)]"
               variants={itemVariants}
               whileHover={{ y: -10 }}
             >
               <motion.div className="h-48 overflow-hidden relative" variants={imageVariants}>
-                {project.image ? (
+                {project.iframePreview ? (
+                  <iframe
+                    src={project.iframePreview}
+                    title={`${project.title} Preview`}
+                    className="w-[200%] h-[200%] origin-top-left scale-50 pointer-events-none"
+                    loading="lazy"
+                    tabIndex={-1}
+                  />
+                ) : project.image ? (
                   <motion.img
                     src={project.image}
                     alt={project.title}


### PR DESCRIPTION
## Summary
- Added a Tool-Call Tactics CTA card with live iframe preview to the hero section
- Added Tool-Call Tactics as a project in the Projects section with iframe preview and GitHub/live links
- Fixed mobile layout so profile photo is visible without scrolling
- Centered the last row of projects grid

## Test plan
- [ ] Verify hero CTA card renders with live preview and links to https://toolcalltactics.loukik.dev
- [ ] Verify profile photo appears at the top on mobile viewports
- [ ] Verify Tool-Call Tactics appears as first project with iframe preview
- [ ] Verify last project row is centered in the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)